### PR TITLE
Set q-val to 1.0 on ZeroDivisionError

### DIFF
--- a/ipaw.nf
+++ b/ipaw.nf
@@ -508,11 +508,17 @@ decoys = {True: 0, False: 0}
 for psm in sorted([(pid, float(p.find('{%s}svm_score' % ns['xmlns']).text), p) for pid, p in psms.items()], reverse=True, key=lambda x:x[1]):
     pdecoy = psm[2].attrib['{%s}decoy' % ns['xmlns']] == 'true'
     decoys[pdecoy] += 1
-    psms[psm[0]] = {'decoy': pdecoy, 'svm': psm[1], 'qval': decoys[True]/decoys[False]}  # T-TDC
+    try:
+        psms[psm[0]] = {'decoy': pdecoy, 'svm': psm[1], 'qval': decoys[True]/decoys[False]}  # T-TDC
+    except ZeroDivisionError:
+        psms[psm[0]] = {'decoy': pdecoy, 'svm': psm[1], 'qval': 1.0}  # T-TDC
 decoys = {'true': 0, 'false': 0}
 for svm, pep in sorted([(float(x.find('{%s}svm_score' % ns['xmlns']).text), x) for x in pycolator.generate_peptides('$perco', ns)], reverse=True, key=lambda x:x[0]):
     decoys[pep.attrib['{%s}decoy' % ns['xmlns']]] += 1
-    [psms[pid.text].update({'pepqval': decoys['true']/decoys['false']}) for pid in pep.find('{%s}psm_ids' % ns['xmlns'])]
+    try:
+        [psms[pid.text].update({'pepqval': decoys['true']/decoys['false']}) for pid in pep.find('{%s}psm_ids' % ns['xmlns'])]
+    except ZeroDivisionError:
+        [psms[pid.text].update({'pepqval': 1.0}) for pid in pep.find('{%s}psm_ids' % ns['xmlns'])]
 oldheader = tsv.get_tsv_header(mzidtsvfns[0])
 header = oldheader + ['percolator svm-score', 'PSM q-value', 'peptide q-value']
 with open('mzidperco', 'w') as fp:


### PR DESCRIPTION
when decoys are found but not tagers the q-val is set to 1.0 to avoid ZeroDivisionError.