### PR TITLE
removed max_target_seqs option in blastp process

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -695,7 +695,7 @@ process BlastPNovel {
   
   """
   makeblastdb -in $blastdb -dbtype prot
-  blastp -db $blastdb -query $novelfasta -outfmt '6 qseqid sseqid pident qlen slen qstart qend sstart send mismatch positive gapopen gaps qseq sseq evalue bitscore' -num_threads 4 -max_target_seqs 1 -evalue 1000 -out blastp_out.txt
+  blastp -db $blastdb -query $novelfasta -outfmt '6 qseqid sseqid pident qlen slen qstart qend sstart send mismatch positive gapopen gaps qseq sseq evalue bitscore' -num_threads 4 -evalue 1000 -out blastp_out.txt
   """
 }
 


### PR DESCRIPTION
Remove the `-max_target_seqs 1` parameter in `blasp` process to avoid early stopping of the algorithm that makes it not find the top best matches. 

See the references [here](https://gist.github.com/sujaikumar/504b3b7024eaf3a04ef5) and [here](https://doi.org/10.1093/bioinformatics/bty833)

https://github.com/lehtiolab/proteogenomics-analysis-workflow/blob/3472dcbaf8b3d20d41a7113519dff691c0a4b0b7/main.nf#L698